### PR TITLE
Add basic parser support for find

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/FindDoctorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindDoctorCommand.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands.exceptions;
+
+public class FindDoctorCommand {
+}

--- a/src/main/java/seedu/address/logic/commands/FindDoctorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindDoctorCommand.java
@@ -1,4 +1,18 @@
-package seedu.address.logic.commands.exceptions;
+package seedu.address.logic.commands;
 
-public class FindDoctorCommand {
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Finds and lists all doctors in address book whose name contains any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindDoctorCommand extends Command {
+    public static final String COMMAND_WORD = "find-doctor";
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "find-doctor command not implemented yet";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/FindDoctorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindDoctorCommand.java
@@ -1,7 +1,12 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
 
 /**
  * Finds and lists all doctors in address book whose name contains any of the argument keywords.
@@ -10,9 +15,41 @@ import seedu.address.model.Model;
 public class FindDoctorCommand extends Command {
     public static final String COMMAND_WORD = "find-doctor";
     public static final String MESSAGE_NOT_IMPLEMENTED_YET = "find-doctor command not implemented yet";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all doctors whose names contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " alice bob charlie";
+
+    private final NameContainsKeywordsPredicate predicate;
+
+    public FindDoctorCommand(NameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
         throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof FindDoctorCommand)) {
+            return false;
+        }
+
+        FindDoctorCommand otherFindDoctorCommand = (FindDoctorCommand) other;
+        return predicate.equals(otherFindDoctorCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -1,12 +1,13 @@
 package seedu.address.logic.commands;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 public class FindPatientCommand extends Command{
     public static final String COMMAND_WORD = "find-patient";
 
     @Override
-    public CommandResult execute(Model model) {
-        return new CommandResult("Find Patient");
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException("Command not implemented yet");
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -28,7 +28,7 @@ public class FindPatientCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET + "Keywords: " + predicate);
+        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all patients in address book whose name contains any of the argument keywords.
@@ -10,9 +14,41 @@ import seedu.address.model.Model;
 public class FindPatientCommand extends Command {
     public static final String COMMAND_WORD = "find-patient";
     public static final String MESSAGE_NOT_IMPLEMENTED_YET = "find-patient command not implemented yet";
+    private final NameContainsKeywordsPredicate predicate;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients whose names contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " alice bob charlie";
+
+    public FindPatientCommand(NameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+        requireNonNull(model);
+        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET + "Keywords: " + predicate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof FindPatientCommand)) {
+            return false;
+        }
+
+        FindPatientCommand otherFindPatientCommand = (FindPatientCommand) other;
+        return predicate.equals(otherFindPatientCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+public class FindPatientCommand extends Command{
+    public static final String COMMAND_WORD = "find-patient";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult("Find Patient");
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -14,12 +14,12 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 public class FindPatientCommand extends Command {
     public static final String COMMAND_WORD = "find-patient";
     public static final String MESSAGE_NOT_IMPLEMENTED_YET = "find-patient command not implemented yet";
-    private final NameContainsKeywordsPredicate predicate;
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
+
+    private final NameContainsKeywordsPredicate predicate;
 
     public FindPatientCommand(NameContainsKeywordsPredicate predicate) {
         this.predicate = predicate;

--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -9,9 +9,10 @@ import seedu.address.model.Model;
  */
 public class FindPatientCommand extends Command {
     public static final String COMMAND_WORD = "find-patient";
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "find-patient command not implemented yet";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("find-patient command not implemented yet");
+        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -3,11 +3,15 @@ package seedu.address.logic.commands;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
-public class FindPatientCommand extends Command{
+/**
+ * Finds and lists all patients in address book whose name contains any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindPatientCommand extends Command {
     public static final String COMMAND_WORD = "find-patient";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("Command not implemented yet");
+        throw new CommandException("find-patient command not implemented yet");
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindPatientCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case FindPatientCommand.COMMAND_WORD:
+            return new FindPatientCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindDoctorCommand;
 import seedu.address.logic.commands.FindPatientCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -80,6 +81,9 @@ public class AddressBookParser {
 
         case FindPatientCommand.COMMAND_WORD:
             return new FindPatientCommand();
+
+        case FindDoctorCommand.COMMAND_WORD:
+            return new FindDoctorCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -83,7 +83,7 @@ public class AddressBookParser {
             return new FindPatientCommandParser().parse(arguments);
 
         case FindDoctorCommand.COMMAND_WORD:
-            return new FindDoctorCommand();
+            return new FindDoctorCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -80,7 +80,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case FindPatientCommand.COMMAND_WORD:
-            return new FindPatientCommand();
+            return new FindPatientCommandParser().parse(arguments);
 
         case FindDoctorCommand.COMMAND_WORD:
             return new FindDoctorCommand();

--- a/src/main/java/seedu/address/logic/parser/FindDoctorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindDoctorCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FindDoctorCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindDoctorCommand object
+ */
+public class FindDoctorCommandParser implements Parser<FindDoctorCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindDoctorCommand
+     * and returns a FindDoctorCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindDoctorCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindDoctorCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindDoctorCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
@@ -26,6 +26,6 @@ public class FindPatientCommandParser {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
-         return new FindPatientCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindPatientCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
@@ -11,7 +11,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 /**
  * Parses input arguments and creates a new FindPatientCommand object
  */
-public class FindPatientCommandParser {
+public class FindPatientCommandParser implements Parser<FindPatientCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindPatientCommand
      * and returns a FindPatientCommand object for execution.

--- a/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FindPatientCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindPatientCommand object
+ */
+public class FindPatientCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindPatientCommand
+     * and returns a FindPatientCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindPatientCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPatientCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+         return new FindPatientCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.FindPatientCommand.MESSAGE_NOT_IMPLEMENTED_YET;
+import static seedu.address.logic.commands.FindDoctorCommand.MESSAGE_NOT_IMPLEMENTED_YET;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -11,13 +11,13 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code FindPatientCommand}. (in the future)
+ * Contains integration tests (interaction with the Model) for {@code FindDoctorCommand}. (in the future)
  */
-public class FindPatientCommandTest {
+public class FindDoctorCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute() {
-        assertCommandFailure(new FindPatientCommand(), model, MESSAGE_NOT_IMPLEMENTED_YET);
+        assertCommandFailure(new FindDoctorCommand(), model, MESSAGE_NOT_IMPLEMENTED_YET);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
@@ -48,7 +48,7 @@ public class FindDoctorCommandTest {
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 
-        @Test
+    @Test
     public void execute() {
         NameContainsKeywordsPredicate firstPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("first"));

--- a/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
@@ -1,14 +1,19 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.FindDoctorCommand.MESSAGE_NOT_IMPLEMENTED_YET;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindDoctorCommand}. (in the future)
@@ -17,7 +22,37 @@ public class FindDoctorCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
+    public void equals() {
+        NameContainsKeywordsPredicate firstPredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
+        NameContainsKeywordsPredicate secondPredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FindDoctorCommand findFirstCommand = new FindDoctorCommand(firstPredicate);
+        FindDoctorCommand findSecondCommand = new FindDoctorCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindDoctorCommand findFirstCommandCopy = new FindDoctorCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+        @Test
     public void execute() {
-        assertCommandFailure(new FindDoctorCommand(), model, MESSAGE_NOT_IMPLEMENTED_YET);
+        NameContainsKeywordsPredicate firstPredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
+        assertCommandFailure(
+                new FindDoctorCommand(firstPredicate), model, MESSAGE_NOT_IMPLEMENTED_YET);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.FindPatientCommand.MESSAGE_NOT_IMPLEMENTED_YET;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -9,6 +11,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+import java.util.Collections;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindPatientCommand}. (in the future)
@@ -17,7 +22,29 @@ public class FindPatientCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute() {
-        assertCommandFailure(new FindPatientCommand(), model, MESSAGE_NOT_IMPLEMENTED_YET);
+    public void equals() {
+        NameContainsKeywordsPredicate firstPredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
+        NameContainsKeywordsPredicate secondPredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FindPatientCommand findFirstCommand = new FindPatientCommand(firstPredicate);
+        FindPatientCommand findSecondCommand = new FindPatientCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindPatientCommand findFirstCommandCopy = new FindPatientCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
@@ -2,9 +2,9 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.FindPatientCommand.MESSAGE_NOT_IMPLEMENTED_YET;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,8 +12,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-
-import java.util.Collections;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindPatientCommand}. (in the future)

--- a/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.FindPatientCommand.MESSAGE_NOT_IMPLEMENTED_YET;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Collections;
@@ -44,5 +46,12 @@ public class FindPatientCommandTest {
 
         // different person -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute() {
+        NameContainsKeywordsPredicate firstPredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
+        assertCommandFailure(new FindPatientCommand(firstPredicate), model, MESSAGE_NOT_IMPLEMENTED_YET);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindPatientCommand}. (in the future)
+ */
+public class FindPatientCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        assertCommandFailure(new FindPatientCommand(), model,"Command not implemented yet");
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindDoctorCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindDoctorCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindDoctorCommand;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+public class FindDoctorCommandParserTest {
+
+    private FindDoctorCommandParser parser = new FindDoctorCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindDoctorCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindPatientCommand() {
+        // no leading and trailing whitespaces
+        FindDoctorCommand expectedFindDoctorCommand =
+                new FindDoctorCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        assertParseSuccess(parser, "Alice Bob", expectedFindDoctorCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindDoctorCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindPatientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindPatientCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindPatientCommand;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+public class FindPatientCommandParserTest {
+
+    private FindPatientCommandParser parser = new FindPatientCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPatientCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindPatientCommand() {
+        // no leading and trailing whitespaces
+        FindPatientCommand expectedFindPatientCommand =
+                new FindPatientCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        assertParseSuccess(parser, "Alice Bob", expectedFindPatientCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindPatientCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindPatientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindPatientCommandParserTest.java
@@ -17,7 +17,8 @@ public class FindPatientCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPatientCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPatientCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
Add basic parser support for both commands:
- [X] `find-patient`
- [x] `find-doctor`

`AddressBookParser` is now able to recognise the two commands, and their respective parsers are also implemented (splitting up the arguments and creating the command for execution). Test cases also made for all new classes and methods created. 