### PR TITLE
Improve find command

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -39,6 +39,27 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code sentence} contains the {@code name}.
+     *  Ignores case, as long as sentence contains name.
+     *  <br>examples:<pre>
+     *      containsNameIgnoreCase("ABc def", "abc") == true //contains abc
+     *      containsNameIgnoreCase("ABc def", "DEF") == true //contains DEF
+     *      containsNameIgnoreCase("ABc def", "ABde") == false //does not contain ABde
+     *      </pre>
+     * @param sentence cannot be null
+     * @param name cannot be null, cannot be empty
+     */
+    public static boolean containsNameIgnoreCase(String sentence, String name) {
+        requireNonNull(sentence);
+        requireNonNull(name);
+
+        String preppedName = name.trim();
+        checkArgument(!preppedName.isEmpty(), "Name parameter cannot be empty");
+
+        return sentence.toLowerCase().contains(preppedName.toLowerCase());
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/logic/parser/FindDoctorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindDoctorCommandParser.java
@@ -26,12 +26,10 @@ public class FindDoctorCommandParser implements Parser<FindDoctorCommand> {
         }
 
         // Ensure that the input is a string of alphabets separated by spaces
-        if (args.matches("^.*[^a-zA-Z ].*$")) {
+        if (trimmedArgs.matches("^.*[^a-zA-Z ].*$")) {
             throw new ParseException(String.format(MESSAGE_INVALID_ARGUMENT_FORMAT, FindDoctorCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindDoctorCommand(new FindDoctorPredicate(Arrays.asList(nameKeywords)));
+        return new FindDoctorCommand(new FindDoctorPredicate(trimmedArgs));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindDoctorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindDoctorCommandParser.java
@@ -3,8 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_ARGUMENT_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.Arrays;
-
 import seedu.address.logic.commands.FindDoctorCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.doctor.FindDoctorPredicate;

--- a/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
@@ -3,8 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_ARGUMENT_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.Arrays;
-
 import seedu.address.logic.commands.FindPatientCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.patient.FindPatientPredicate;

--- a/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPatientCommandParser.java
@@ -26,12 +26,10 @@ public class FindPatientCommandParser implements Parser<FindPatientCommand> {
         }
 
         // Ensure that the input is a string of alphabets separated by spaces
-        if (args.matches("^.*[^a-zA-Z ].*$")) {
+        if (trimmedArgs.matches("^.*[^a-zA-Z ].*$")) {
             throw new ParseException(String.format(MESSAGE_INVALID_ARGUMENT_FORMAT, FindPatientCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindPatientCommand(new FindPatientPredicate(Arrays.asList(nameKeywords)));
+        return new FindPatientCommand(new FindPatientPredicate(trimmedArgs));
     }
 }

--- a/src/main/java/seedu/address/model/doctor/FindDoctorPredicate.java
+++ b/src/main/java/seedu/address/model/doctor/FindDoctorPredicate.java
@@ -11,10 +11,10 @@ import seedu.address.model.person.Person;
  * Tests that a {@code Person} is an instanceof Doctor and contains any of the keywords given.
  */
 public class FindDoctorPredicate implements Predicate<Person> {
-    private final List<String> keywords;
+    private final String name;
 
-    public FindDoctorPredicate(List<String> keywords) {
-        this.keywords = keywords;
+    public FindDoctorPredicate(String name) {
+        this.name = name;
     }
 
     @Override
@@ -22,8 +22,7 @@ public class FindDoctorPredicate implements Predicate<Person> {
         if (!(person instanceof Doctor)) {
             return false;
         }
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+        return StringUtil.containsNameIgnoreCase(person.getName().fullName, name);
     }
 
     @Override
@@ -37,11 +36,11 @@ public class FindDoctorPredicate implements Predicate<Person> {
         }
 
         FindDoctorPredicate findDoctorPredicate = (FindDoctorPredicate) other;
-        return keywords.equals(findDoctorPredicate.keywords);
+        return name.equals(findDoctorPredicate.name);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", keywords).toString();
+        return new ToStringBuilder(this).add("name", name).toString();
     }
 }

--- a/src/main/java/seedu/address/model/doctor/FindDoctorPredicate.java
+++ b/src/main/java/seedu/address/model/doctor/FindDoctorPredicate.java
@@ -1,6 +1,5 @@
 package seedu.address.model.doctor;
 
-import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;

--- a/src/main/java/seedu/address/model/patient/FindPatientPredicate.java
+++ b/src/main/java/seedu/address/model/patient/FindPatientPredicate.java
@@ -1,6 +1,5 @@
 package seedu.address.model.patient;
 
-import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;

--- a/src/main/java/seedu/address/model/patient/FindPatientPredicate.java
+++ b/src/main/java/seedu/address/model/patient/FindPatientPredicate.java
@@ -11,10 +11,10 @@ import seedu.address.model.person.Person;
  * Tests that a {@code Person}'s is a patient and {@code Name} matches any of the keywords given.
  */
 public class FindPatientPredicate implements Predicate<Person> {
-    private final List<String> keywords;
+    private final String name;
 
-    public FindPatientPredicate(List<String> keywords) {
-        this.keywords = keywords;
+    public FindPatientPredicate(String name) {
+        this.name = name;
     }
 
     @Override
@@ -22,8 +22,7 @@ public class FindPatientPredicate implements Predicate<Person> {
         if (!(person instanceof Patient)) {
             return false;
         }
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+        return StringUtil.containsNameIgnoreCase(person.getName().fullName, name);
     }
 
     @Override
@@ -37,11 +36,11 @@ public class FindPatientPredicate implements Predicate<Person> {
         }
 
         FindPatientPredicate findPatientPredicate = (FindPatientPredicate) other;
-        return keywords.equals(findPatientPredicate.keywords);
+        return name.equals(findPatientPredicate.name);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", keywords).toString();
+        return new ToStringBuilder(this).add("keywords", name).toString();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
@@ -29,9 +29,9 @@ public class FindDoctorCommandTest {
     @Test
     public void equals() {
         FindDoctorPredicate firstPredicate =
-                new FindDoctorPredicate(Collections.singletonList("first"));
+                new FindDoctorPredicate("first");
         FindDoctorPredicate secondPredicate =
-                new FindDoctorPredicate(Collections.singletonList("second"));
+                new FindDoctorPredicate("second");
 
         FindDoctorCommand findFirstCommand = new FindDoctorCommand(firstPredicate);
         FindDoctorCommand findSecondCommand = new FindDoctorCommand(secondPredicate);
@@ -56,7 +56,7 @@ public class FindDoctorCommandTest {
     @Test
     public void execute_zeroKeyword_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_DOCTORS_LISTED_OVERVIEW, 0);
-        FindDoctorPredicate predicate = preparePredicate(" ");
+        FindDoctorPredicate predicate = preparePredicate("Karen KENNEDY");
         FindDoctorCommand command = new FindDoctorCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -73,17 +73,7 @@ public class FindDoctorCommandTest {
         assertEquals(Arrays.asList(KAREN), model.getFilteredPersonList());
     }
 
-    @Test
-    public void execute_multipleKeywords_multiplePersonFound() {
-        String expectedMessage = String.format(MESSAGE_DOCTORS_LISTED_OVERVIEW, 2);
-        FindDoctorPredicate predicate = preparePredicate("Karen KENNEDY");
-        FindDoctorCommand command = new FindDoctorCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(KENNEDY, KAREN), model.getFilteredPersonList());
-    }
-
     private FindDoctorPredicate preparePredicate(String userInput) {
-        return new FindDoctorPredicate(Arrays.asList(userInput.split("\\s+")));
+        return new FindDoctorPredicate(userInput);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindDoctorCommandTest.java
@@ -6,11 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_DOCTORS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.KAREN;
-import static seedu.address.testutil.TypicalPersons.KENNEDY;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookWithDoctors;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
@@ -29,9 +29,9 @@ public class FindPatientCommandTest {
     @Test
     public void equals() {
         FindPatientPredicate firstPredicate =
-                new FindPatientPredicate(Collections.singletonList("first"));
+                new FindPatientPredicate("first");
         FindPatientPredicate secondPredicate =
-                new FindPatientPredicate(Collections.singletonList("second"));
+                new FindPatientPredicate("second");
 
         FindPatientCommand findFirstCommand = new FindPatientCommand(firstPredicate);
         FindPatientCommand findSecondCommand = new FindPatientCommand(secondPredicate);
@@ -56,7 +56,7 @@ public class FindPatientCommandTest {
     @Test
     public void execute_zeroKeyword_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PATIENTS_LISTED_OVERVIEW, 0);
-        FindPatientPredicate predicate = preparePredicate(" ");
+        FindPatientPredicate predicate = preparePredicate("jane john");
         FindPatientCommand command = new FindPatientCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -73,17 +73,7 @@ public class FindPatientCommandTest {
         assertEquals(Arrays.asList(JANE), model.getFilteredPersonList());
     }
 
-    @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PATIENTS_LISTED_OVERVIEW, 2);
-        FindPatientPredicate predicate = preparePredicate("jane john");
-        FindPatientCommand command = new FindPatientCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(JOHN, JANE), model.getFilteredPersonList());
-    }
-
     private FindPatientPredicate preparePredicate(String userInput) {
-        return new FindPatientPredicate(Arrays.asList(userInput.split("\\s+")));
+        return new FindPatientPredicate(userInput);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_PATIENTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.JANE;
-import static seedu.address.testutil.TypicalPersons.JOHN;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookWithPatients;
 
 import java.util.Arrays;

--- a/src/test/java/seedu/address/logic/parser/FindDoctorCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindDoctorCommandParserTest.java
@@ -31,13 +31,13 @@ public class FindDoctorCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindPatientCommand() {
+    public void parse_validArgs_returnsFindDoctorCommand() {
         // no leading and trailing whitespaces
         FindDoctorCommand expectedFindDoctorCommand =
-                new FindDoctorCommand(new FindDoctorPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindDoctorCommand);
+                new FindDoctorCommand(new FindDoctorPredicate("Alice"));
+        assertParseSuccess(parser, "Alice", expectedFindDoctorCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindDoctorCommand);
+        assertParseSuccess(parser, " \n Alice ", expectedFindDoctorCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindDoctorCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindDoctorCommandParserTest.java
@@ -5,8 +5,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindDoctorCommand;

--- a/src/test/java/seedu/address/logic/parser/FindPatientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindPatientCommandParserTest.java
@@ -34,10 +34,10 @@ public class FindPatientCommandParserTest {
     public void parse_validArgs_returnsFindPatientCommand() {
         // no leading and trailing whitespaces
         FindPatientCommand expectedFindPatientCommand =
-                new FindPatientCommand(new FindPatientPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindPatientCommand);
+                new FindPatientCommand(new FindPatientPredicate("Alice"));
+        assertParseSuccess(parser, "Alice", expectedFindPatientCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindPatientCommand);
+        assertParseSuccess(parser, " \n Alice", expectedFindPatientCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindPatientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindPatientCommandParserTest.java
@@ -5,8 +5,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindPatientCommand;


### PR DESCRIPTION
`find-doctor <NAME>` and `find-patient <NAME>` now searches for matches with the whole string, instead of splitting the string from whitespace.

Expected Behaviour:
If there is a Doctor with name "Jane Doe", it will match with "Jane", "Doe" , "Jane Doe" and "Ja ".
But, it will not match with "Jane Doh", or "John Doe".

Resolves #106 