### PR TITLE
Fix duplicate check for appointments

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
@@ -78,14 +78,23 @@ public class AddAppointmentCommand extends Command {
 
         Person patientToEdit = patient.get();
         Person doctorToEdit = doctor.get();
-        this.appointmentToAdd = new Appointment((Doctor) doctorToEdit, (Patient) patientToEdit, this.date, this.time);
 
         Person editedPatient;
         Person editedDoctor;
 
-        if (model.hasAppointment(appointmentToAdd)) {
+        Appointment appointment = new Appointment((Doctor) doctorToEdit, (Patient) patientToEdit, this.date, this.time);
+        if (model.hasAppointment(appointment)) {
             throw new CommandException(MESSAGE_DUPLICATE_APPOINTMENT);
         }
+
+        // Only call createAppointment() if it isn't a duplicate
+        // This avoids linking a duplicate appointment to the Doctor and Patient classes
+        this.appointmentToAdd = Appointment.createAppointment(
+            (Doctor) doctorToEdit,
+            (Patient) patientToEdit,
+            this.date,
+            this.time
+        );
 
         editedPatient = patientToEdit;
         editedDoctor = doctorToEdit;

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -53,7 +53,13 @@ public class Appointment {
      * Automatically assigns a new random unique ID.
      */
     public Appointment(Doctor doctor, Patient patient, Date date, Time time) {
-        this(getNewId(), doctor, patient, date, time);
+        requireAllNonNull(doctor, patient, date, time);
+
+        this.id = getNewId();
+        this.doctor = doctor;
+        this.patient = patient;
+        this.date = date;
+        this.time = time;
     }
 
     private static Integer getNewId() {
@@ -64,6 +70,15 @@ public class Appointment {
         } while (appointmentById.containsKey(newId) || newId <= 0);
 
         return newId;
+    }
+
+    /**
+     * Factory method to create a new appointment from data fields.
+     * Automatically assigns a new random unique ID.
+     * Links the appointments to the doctor/patient and adds it to the hashtable.
+     */
+    public static Appointment createAppointment(Doctor doctor, Patient patient, Date date, Time time) {
+        return new Appointment(getNewId(), doctor, patient, date, time);
     }
 
     /**
@@ -123,7 +138,7 @@ public class Appointment {
     }
 
     /**
-     * Returns true if both appointments have the same ID.
+     * Returns true if both appointments have the same fields (excluding ID).
      * This defines a weaker notion of equality between two appointments.
      */
     public boolean isSameAppointment(Appointment otherAppointment) {
@@ -132,7 +147,10 @@ public class Appointment {
         }
 
         return otherAppointment != null
-                && getId().equals(otherAppointment.getId());
+            && doctor.equals(otherAppointment.doctor)
+            && patient.equals(otherAppointment.patient)
+            && date.equals(otherAppointment.date)
+            && time.equals(otherAppointment.time);
     }
 
     /**

--- a/src/test/java/seedu/address/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTest.java
@@ -26,7 +26,7 @@ public class AppointmentTest {
     @Test
     public void deleteAppointmentById() {
         // Create new appointment
-        Appointment appointment = new Appointment(
+        Appointment appointment = Appointment.createAppointment(
             ALICE, DANIEL, new DateOfBirth("12-02-2024"), new Time("0900")
         );
 
@@ -42,6 +42,11 @@ public class AppointmentTest {
     public void isSameAppointment() {
         // same object -> returns true
         assertTrue(APPOINTMENT_A.isSameAppointment(APPOINTMENT_A));
+
+        // same fields -> returns true
+        assertTrue(APPOINTMENT_A.isSameAppointment(new Appointment(
+            ALICE, CARL, new DateOfBirth("11-02-2024"), new Time("2359")
+        )));
 
         // null -> returns false
         assertFalse(APPOINTMENT_A.isSameAppointment(null));


### PR DESCRIPTION
Modify `Appointment.isSameAppointment()` to check equivalence based on data fields instead of its ID.

Closes #141.