### PR TITLE
Fix bug regarding storage duplicates

### DIFF
--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -182,8 +182,17 @@ public class UniquePersonList implements Iterable<Person> {
     private boolean personsAreUnique(List<Person> persons) {
         for (int i = 0; i < persons.size() - 1; i++) {
             for (int j = i + 1; j < persons.size(); j++) {
-                if (persons.get(i).isSamePerson(persons.get(j))) {
-                    return false;
+                Person first = persons.get(i);
+                Person second = persons.get(j);
+                // Check if they are both patients or doctors first.
+                if (first instanceof Patient && second instanceof Patient) {
+                    if (((Patient) first).isSamePatient((Patient) second)) {
+                        return false;
+                    }
+                } else if (first instanceof Doctor && second instanceof Doctor) {
+                    if (((Doctor) first).isSameDoctor((Doctor) second)) {
+                        return false;
+                    }
                 }
             }
         }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -70,15 +70,19 @@ class JsonSerializableAddressBook {
                 }
                 doctorList.add(doctor);
                 addressBook.addDoctor(doctor);
-            }
-
-            if (person instanceof Patient) {
+            } else if (person instanceof Patient) {
                 Patient patient = (Patient) person;
                 if (addressBook.hasPatient(patient)) {
                     throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
                 }
                 patientList.add(patient);
                 addressBook.addPatient(patient);
+            } else {
+                if (addressBook.hasPerson(person)) {
+                    throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
+                }
+
+                addressBook.addPerson(person);
             }
         }
 

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -62,17 +62,24 @@ class JsonSerializableAddressBook {
         List<Patient> patientList = new ArrayList<>();
         for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
             Person person = jsonAdaptedPerson.toModelType();
-            if (addressBook.hasPerson(person)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
-            }
+
             if (person instanceof Doctor) {
-                doctorList.add((Doctor) person);
+                Doctor doctor = (Doctor) person;
+                if (addressBook.hasDoctor(doctor)) {
+                    throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
+                }
+                doctorList.add(doctor);
+                addressBook.addDoctor(doctor);
             }
 
             if (person instanceof Patient) {
-                patientList.add((Patient) person);
+                Patient patient = (Patient) person;
+                if (addressBook.hasPatient(patient)) {
+                    throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
+                }
+                patientList.add(patient);
+                addressBook.addPatient(patient);
             }
-            addressBook.addPerson(person);
         }
 
         for (JsonAdaptedAppointment jsonAdaptedAppointment : appointments) {

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -54,13 +54,27 @@ public class AddressBookTest {
     }
 
     @Test
-    public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
-        // Two persons with the same identity fields
-        Person editedAlice = new PersonBuilder(ALICE)
+    public void resetData_withDuplicateDoctors_throwsDuplicatePersonException() {
+        // Two doctors with the same identity fields
+        Doctor editedDaniel = new DoctorBuilder(DANIEL)
                 .withAddress(VALID_ADDRESS_BOB)
                 .withTags(VALID_TAG_HUSBAND)
                 .build();
-        List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
+        List<Person> newPersons = Arrays.asList(DANIEL, editedDaniel);
+        List<Appointment> newAppointments = new ArrayList<>();
+        AddressBookStub newData = new AddressBookStub(newPersons, newAppointments);
+
+        assertThrows(DuplicatePersonException.class, () -> addressBook.resetData(newData));
+    }
+
+    @Test
+    public void resetData_withDuplicatePatient_throwsDuplicatePersonException() {
+        // Two patients with the same identity fields
+        Patient editedCarl = new PatientBuilder(CARL)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND)
+                .build();
+        List<Person> newPersons = Arrays.asList(CARL, editedCarl);
         List<Appointment> newAppointments = new ArrayList<>();
         AddressBookStub newData = new AddressBookStub(newPersons, newAppointments);
 

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -163,9 +163,15 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPersons_listWithDuplicatePersons_throwsDuplicatePersonException() {
-        List<Person> listWithDuplicatePersons = Arrays.asList(ALICE, ALICE);
-        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setPersons(listWithDuplicatePersons));
+    public void setPersons_listWithDuplicateDoctors_throwsDuplicatePersonException() {
+        List<Person> listWithDuplicateDoctors = Arrays.asList(DANIEL, DANIEL);
+        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setPersons(listWithDuplicateDoctors));
+    }
+
+    @Test
+    public void setPersons_listWithDuplicatePatients_throwsDuplicatePersonException() {
+        List<Person> listWithDuplicatePatients = Arrays.asList(CARL, CARL);
+        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setPersons(listWithDuplicatePatients));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -3,9 +3,9 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalDoctors.HOON;
+import static seedu.address.testutil.TypicalPatients.IDA;
 import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.HOON;
-import static seedu.address.testutil.TypicalPersons.IDA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
@@ -72,14 +72,14 @@ public class JsonAddressBookStorageTest {
         assertEquals(original, new AddressBook(readBack));
 
         // Modify data, overwrite exiting file, and read back
-        original.addPerson(HOON);
+        original.addDoctor(HOON);
         original.removePerson(ALICE);
         jsonAddressBookStorage.saveAddressBook(original, filePath);
         readBack = jsonAddressBookStorage.readAddressBook(filePath).get();
         assertEquals(original, new AddressBook(readBack));
 
         // Save and read without specifying file path
-        original.addPerson(IDA);
+        original.addPatient(IDA);
         jsonAddressBookStorage.saveAddressBook(original); // file path not specified
         readBack = jsonAddressBookStorage.readAddressBook().get(); // file path not specified
         assertEquals(original, new AddressBook(readBack));


### PR DESCRIPTION
* Resolves #231

Fix bug regarding patient and doctors with the same name not being handled properly in the storage. 
Now, storage will not throw an error if doctors and patients with the same name are present in the `.json` file.

Do help me test properly to ensure the issue is resolved.